### PR TITLE
Fix for the userwarning in pytorch 0.3

### DIFF
--- a/gan_pytorch.py
+++ b/gan_pytorch.py
@@ -98,14 +98,14 @@ for epoch in range(num_epochs):
         #  1A: Train D on real
         d_real_data = Variable(d_sampler(d_input_size))
         d_real_decision = D(preprocess(d_real_data))
-        d_real_error = criterion(d_real_decision, Variable(torch.ones(1)))  # ones = true
+        d_real_error = criterion(d_real_decision, Variable(torch.ones(1, 1)))  # ones = true
         d_real_error.backward() # compute/store gradients, but don't change params
 
         #  1B: Train D on fake
         d_gen_input = Variable(gi_sampler(minibatch_size, g_input_size))
         d_fake_data = G(d_gen_input).detach()  # detach to avoid training G on these labels
         d_fake_decision = D(preprocess(d_fake_data.t()))
-        d_fake_error = criterion(d_fake_decision, Variable(torch.zeros(1)))  # zeros = fake
+        d_fake_error = criterion(d_fake_decision, Variable(torch.zeros(1, 1)))  # zeros = fake
         d_fake_error.backward()
         d_optimizer.step()     # Only optimizes D's parameters; changes based on stored gradients from backward()
 
@@ -116,7 +116,7 @@ for epoch in range(num_epochs):
         gen_input = Variable(gi_sampler(minibatch_size, g_input_size))
         g_fake_data = G(gen_input)
         dg_fake_decision = D(preprocess(g_fake_data.t()))
-        g_error = criterion(dg_fake_decision, Variable(torch.ones(1)))  # we want to fool, so pretend it's all genuine
+        g_error = criterion(dg_fake_decision, Variable(torch.ones(1, 1)))  # we want to fool, so pretend it's all genuine
 
         g_error.backward()
         g_optimizer.step()  # Only optimizes G's parameters


### PR DESCRIPTION
UserWarning: Using a target size (torch.Size([1])) that is different to the input size (torch.Size([1, 1])) is deprecated. Please ensure they have the same size.